### PR TITLE
Update forward guide link, add folder download link

### DIFF
--- a/howtos/how-to-add-forwarding/README.md
+++ b/howtos/how-to-add-forwarding/README.md
@@ -1,8 +1,6 @@
 # How to add message forwarding to your chat
 
-<!-- TO DO: add link to tutorial -->
-
-This is an example project for TalkJS's tutorial on how to add message forwarding to your chat. 
+This is an example project for TalkJS's tutorial on [How to add a forward message feature to your chat](https://talkjs.com/resources/how-to-add-a-forward-message-feature/). 
 
 ![An inbox pre-built chat UI with on the left a list of conversations with one conversation selected. On the right it shows the selected conversation. The conversation contains three messages, of which the last message has at the top of the message body a right-pointing arrow and the italicized text ‘Forwarded’.](/howtos/how-to-add-forwarding/1-demo.gif)
 *A conversation with a forwarded message*

--- a/howtos/how-to-add-forwarding/README.md
+++ b/howtos/how-to-add-forwarding/README.md
@@ -1,5 +1,8 @@
 # How to add message forwarding to your chat
 
+> [!TIP]
+> [Download this example project as a zip file](https://download-directory.github.io?url=https://github.com/talkjs/talkjs-examples/tree/master/howtos/how-to-add-forwarding) (using a GitHub folder download tool)
+
 This is an example project for TalkJS's tutorial on [How to add a forward message feature to your chat](https://talkjs.com/resources/how-to-add-a-forward-message-feature/). 
 
 ![An inbox pre-built chat UI with on the left a list of conversations with one conversation selected. On the right it shows the selected conversation. The conversation contains three messages, of which the last message has at the top of the message body a right-pointing arrow and the italicized text ‘Forwarded’.](/howtos/how-to-add-forwarding/1-demo.gif)


### PR DESCRIPTION
This change:
- Adds a link to the step-by-step tutorial.
- Adds a direct download link using the [download-directory](https://download-directory.github.io/) tool, [as discussed on Slack](https://talkjs.slack.com/archives/C05N5AYM353/p1731651655976649). Formatted the link using the [**Tip** Notes option](https://gist.github.com/Myndex/5140d6fe98519bb15c503c490e713233#new-notes).