### PR TITLE
Add READMEs to empty directories in Sendbird migration example

### DIFF
--- a/rest-api/migrate-data-from-sendbird-to-talkjs/importers/channelImporter.js
+++ b/rest-api/migrate-data-from-sendbird-to-talkjs/importers/channelImporter.js
@@ -12,6 +12,12 @@ const instance = axios.create({
 
 async function importChannels(filePath) {
   try {
+    // Check if file is JSON
+    if (!filePath.toLowerCase().endsWith(".json")) {
+      console.log(`Skipping non-JSON file: ${filePath}`);
+      return;
+    }
+
     // Read and parse file
     const data = await fs.readFile(filePath, "utf8");
     console.log(`Read file: ${filePath}`);

--- a/rest-api/migrate-data-from-sendbird-to-talkjs/importers/messageImporter.js
+++ b/rest-api/migrate-data-from-sendbird-to-talkjs/importers/messageImporter.js
@@ -75,6 +75,12 @@ async function importBatch(conversationId, messages) {
 
 async function importMessages(filePath) {
   try {
+    // Check if file is JSON
+    if (!filePath.toLowerCase().endsWith(".json")) {
+      console.log(`Skipping non-JSON file: ${filePath}`);
+      return;
+    }
+
     // Read and parse file
     const data = await fs.readFile(filePath, "utf8");
     console.log(`Read file: ${filePath}`);

--- a/rest-api/migrate-data-from-sendbird-to-talkjs/importers/userImporter.js
+++ b/rest-api/migrate-data-from-sendbird-to-talkjs/importers/userImporter.js
@@ -12,6 +12,12 @@ const instance = axios.create({
 
 async function importUsers(filePath) {
   try {
+    // Check if file is JSON
+    if (!filePath.toLowerCase().endsWith(".json")) {
+      console.log(`Skipping non-JSON file: ${filePath}`);
+      return;
+    }
+
     // Read and parse file
     const data = await fs.readFile(filePath, "utf8");
     console.log(`Read file: ${filePath}`);

--- a/rest-api/migrate-data-from-sendbird-to-talkjs/sendbird-data/channels/README.md
+++ b/rest-api/migrate-data-from-sendbird-to-talkjs/sendbird-data/channels/README.md
@@ -1,0 +1,1 @@
+Add your channel data files in this directory

--- a/rest-api/migrate-data-from-sendbird-to-talkjs/sendbird-data/messages/README.md
+++ b/rest-api/migrate-data-from-sendbird-to-talkjs/sendbird-data/messages/README.md
@@ -1,0 +1,1 @@
+Add your message data files in this directory

--- a/rest-api/migrate-data-from-sendbird-to-talkjs/sendbird-data/users/README.md
+++ b/rest-api/migrate-data-from-sendbird-to-talkjs/sendbird-data/users/README.md
@@ -1,0 +1,1 @@
+Add your user data files in this directory


### PR DESCRIPTION
The `sendbird-data` directories were missing because Git doesn't commit empty directories. I've added a README to each to get round this.

Also updated importers to only run on JSON files (to stop them trying to eat the README, but good to have anyway)

@csmeyns thanks for spotting this! A quick check that this makes sense would be great 🙂 