### PR TITLE
Add transfer-data sample

### DIFF
--- a/rest-api/transfer-data/README.md
+++ b/rest-api/transfer-data/README.md
@@ -1,0 +1,64 @@
+# Transfer TalkJS data between apps
+
+This example shows how you can copy users, conversations, and messages from one TalkJS app to another using the REST API.
+
+It is useful when you want to move data between environments (for example from a test app to another test app), or between TalkJS apps you control.
+
+> [!TIP]
+> [Download this example project as a zip file](https://github.com/talkjs/talkjs-examples/releases/latest/download/rest-api.transfer-data.zip)
+
+## Usage
+
+1. Open `transferData.js` and set the origin and destination credentials from the [TalkJS Dashboard](https://talkjs.com/dashboard/):
+
+```js
+const originApp = {
+    id: "ORIGIN_APP_ID",
+    secretKey: "sk_test...",
+};
+
+const destinationApp = {
+    id: "DESTINATION_APP_ID",
+    secretKey: "sk_test...",
+};
+
+// Optional: also copy emoji reactions after messages are imported
+const includeReactions = false;
+```
+
+2. Install dependencies and run the script:
+
+```bash
+npm i && node transferData.js
+```
+
+The script:
+
+1. Exports all users, conversations, and messages from the origin app
+2. Imports users into the destination app
+3. Imports conversations (including participant access and notification settings), noting which ones already existed
+4. Imports messages only into conversations that did not already exist on the destination (message import is not idempotent)
+5. Optionally re-adds emoji reactions (`includeReactions`)
+6. Restores each participant's `readUntil` value for newly imported conversations
+7. Prints progress as it goes
+
+Try the transfer against a test destination app first. If something goes wrong, you can use **Reset all data** on the Settings page of the TalkJS dashboard to clear the destination app and try again.
+
+## Limitations
+
+This is intentionally a simple, one-shot transfer script. Keep the following in mind:
+
+- **Point-in-time copy.** The script exports data once at the start of each stage. Users, conversations, or messages created or changed in the origin app after that export are not transferred.
+- **No live sync.** The destination app is not kept in sync after the script finishes. New activity in the origin app must be transferred again separately (or handled by your own ongoing sync process).
+- **Message import is skipped for existing conversations.** Users and conversations are upserted, so re-running updates those. Before creating/updating each conversation, the script checks whether it already exists on the destination; if it does, messages (and reactions) for that conversation are skipped. This avoids duplicating messages on re-runs, but also means new origin messages are not added to conversations that already exist on the destination.
+- **Attachment re-upload.** File attachments are downloaded from the origin and uploaded again to the destination. If a download or upload fails, that attachment is skipped and the script continues. The same origin file URL is only uploaded once.
+- **Message IDs change.** TalkJS assigns new message IDs on import, so reply references (`referencedMessageId`) are not preserved.
+- **Reactions are opt-in.** The import API does not support reactions, so when `includeReactions` is `true` the script re-adds them afterward with the normal reactions endpoints. This is slower, reaction timestamps are not preserved (they become "now"), and only the first 100 reactors per emoji on a message are transferred.
+- **Push tokens are not transferred.** Device push tokens stay on the origin app.
+- **No deletion sync.** Users, conversations, or messages deleted in the origin app are not deleted from the destination app.
+- **Active clients.** Imported messages are not pushed to clients that already have a conversation open. Users may need to reload before they see imported history.
+
+## Related
+
+- [Export TalkJS data](../export-data/) — export users, conversations, and messages to JSON files
+- [Import messages](https://talkjs.com/docs/REST_API/Import_Messages/) — TalkJS REST API docs for importing historical messages

--- a/rest-api/transfer-data/package-lock.json
+++ b/rest-api/transfer-data/package-lock.json
@@ -1,0 +1,297 @@
+{
+  "name": "transfer-data",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "form-data": "^4.0.6",
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/rest-api/transfer-data/package.json
+++ b/rest-api/transfer-data/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "dependencies": {
+    "form-data": "^4.0.6",
+    "node-fetch": "^2.6.1"
+  }
+}

--- a/rest-api/transfer-data/transferData.js
+++ b/rest-api/transfer-data/transferData.js
@@ -1,0 +1,633 @@
+import fetch from "node-fetch";
+import FormData from "form-data";
+
+const host = "https://api.talkjs.com";
+
+// Modify these to the credentials found in the TalkJS dashboard (https://talkjs.com/dashboard)
+const originApp = {
+  id: "ORIGIN_APP_ID",
+  secretKey: "sk_test...",
+};
+
+const destinationApp = {
+  id: "DESTINATION_APP_ID",
+  secretKey: "sk_test...",
+};
+
+// Set to true to copy emoji reactions after messages are imported.
+// This is slower (extra API calls per reacted message) and does not preserve
+// the original reaction timestamps.
+const includeReactions = false;
+
+const MESSAGE_BATCH_SIZE = 100;
+const REQUEST_DELAY_MS = 250;
+
+// Cache of origin file URL -> destination fileToken, so shared attachments are only uploaded once.
+const uploadedFileTokens = new Map();
+
+async function transfer() {
+  assertConfigured(originApp, "origin");
+  assertConfigured(destinationApp, "destination");
+
+  console.log(`Transferring data from ${originApp.id} to ${destinationApp.id}`);
+  console.log(`includeReactions: ${includeReactions}`);
+  console.log(
+    "Note: this is a point-in-time copy. Changes made in the origin app after the transfer starts are not included.\n",
+  );
+
+  console.log("=== Exporting users from origin ===");
+  const users = await listResources({
+    app: originApp,
+    resource: "users",
+    limit: 100,
+  });
+  console.log(`Found ${users.length} users.\n`);
+
+  console.log("=== Exporting conversations from origin ===");
+  const conversations = await listResources({
+    app: originApp,
+    resource: "conversations",
+    limit: 30,
+  });
+  console.log(`Found ${conversations.length} conversations.\n`);
+
+  console.log("=== Exporting messages from origin ===");
+  const messagesByConversation = {};
+  let totalMessages = 0;
+  for (let i = 0; i < conversations.length; i++) {
+    const conversation = conversations[i];
+    const messages = await listResources({
+      app: originApp,
+      resource: `conversations/${conversation.id}/messages`,
+      limit: 100,
+    });
+    messagesByConversation[conversation.id] = messages;
+    totalMessages += messages.length;
+    console.log(
+      `  [${i + 1}/${conversations.length}] ${conversation.id}: ${messages.length} messages`,
+    );
+  }
+  console.log(`Found ${totalMessages} messages in total.\n`);
+
+  console.log("=== Importing users into destination ===");
+  for (let i = 0; i < users.length; i++) {
+    const user = users[i];
+    await putUser(destinationApp, user);
+    console.log(`  [${i + 1}/${users.length}] Imported user ${user.id}`);
+  }
+  console.log(`Imported ${users.length} users.\n`);
+
+  console.log("=== Importing conversations into destination ===");
+  // Conversations that already exist on the destination before this run.
+  // Message import is not idempotent, so we skip importing messages into these.
+  const existingConversationIds = new Set();
+  for (let i = 0; i < conversations.length; i++) {
+    const conversation = conversations[i];
+    const alreadyExists = await conversationExists(destinationApp, conversation.id);
+    if (alreadyExists) {
+      existingConversationIds.add(conversation.id);
+    }
+
+    await putConversation(destinationApp, conversation);
+    console.log(
+      `  [${i + 1}/${conversations.length}] ${alreadyExists ? "Updated" : "Imported"} conversation ${conversation.id}`,
+    );
+  }
+  console.log(
+    `Processed ${conversations.length} conversations ` +
+      `(${existingConversationIds.size} already existed; messages will be skipped for those).\n`,
+  );
+
+  console.log("=== Importing messages into destination ===");
+  let importedMessages = 0;
+  let skippedExistingConversations = 0;
+  let transferredAttachments = 0;
+  let failedAttachments = 0;
+  let transferredReactions = 0;
+  let failedReactions = 0;
+  for (let i = 0; i < conversations.length; i++) {
+    const conversation = conversations[i];
+
+    if (existingConversationIds.has(conversation.id)) {
+      skippedExistingConversations++;
+      console.log(
+        `  [${i + 1}/${conversations.length}] ${conversation.id}: skipped messages (conversation already existed)`,
+      );
+      continue;
+    }
+
+    const messages = [...(messagesByConversation[conversation.id] || [])].sort(
+      (a, b) => a.createdAt - b.createdAt,
+    );
+
+    const importable = [];
+    for (const message of messages) {
+      const prepared = await prepareMessageForImport(destinationApp, message);
+      transferredAttachments += prepared.transferredAttachments;
+      failedAttachments += prepared.failedAttachments;
+      if (prepared.message) {
+        importable.push({ originMessage: message, payload: prepared.message });
+      }
+    }
+
+    for (
+      let offset = 0;
+      offset < importable.length;
+      offset += MESSAGE_BATCH_SIZE
+    ) {
+      const batch = importable.slice(offset, offset + MESSAGE_BATCH_SIZE);
+      const createdMessages = await importMessages(
+        destinationApp,
+        conversation.id,
+        batch.map((item) => item.payload),
+      );
+      importedMessages += batch.length;
+
+      if (includeReactions) {
+        const reactionResult = await transferReactionsForBatch({
+          conversationId: conversation.id,
+          batch,
+          createdMessages,
+        });
+        transferredReactions += reactionResult.transferred;
+        failedReactions += reactionResult.failed;
+      }
+    }
+
+    await setParticipantReadUntil(destinationApp, conversation);
+
+    console.log(
+      `  [${i + 1}/${conversations.length}] ${conversation.id}: imported ${importable.length} messages`,
+    );
+  }
+
+  console.log(`\nTransfer complete.`);
+  console.log(`  Users: ${users.length}`);
+  console.log(`  Conversations: ${conversations.length}`);
+  console.log(`  Messages imported: ${importedMessages}`);
+  console.log(
+    `  Conversations skipped for messages (already existed): ${skippedExistingConversations}`,
+  );
+  console.log(`  File attachments transferred: ${transferredAttachments}`);
+  if (failedAttachments > 0) {
+    console.log(`  File attachments failed: ${failedAttachments}`);
+  }
+  if (includeReactions) {
+    console.log(`  Reactions transferred: ${transferredReactions}`);
+    if (failedReactions > 0) {
+      console.log(`  Reactions failed: ${failedReactions}`);
+    }
+  }
+}
+
+function assertConfigured(app, label) {
+  if (
+    !app.id ||
+    app.id.includes("APP_ID") ||
+    !app.secretKey ||
+    app.secretKey.includes("...")
+  ) {
+    throw new Error(
+      `Set the ${label} app ID and secret key at the top of transferData.js before running.`,
+    );
+  }
+}
+
+async function listResources({ app, resource, lastId, limit }) {
+  const paginateMaybe = lastId ? `&startingAfter=${lastId}` : "";
+  const path = `${host}/v1/${app.id}/${resource}?limit=${limit}${paginateMaybe}`;
+  const resources = await doRequest(path, app.secretKey, "GET");
+
+  if (resources.length === limit) {
+    const last = resources[resources.length - 1];
+    const newOnes = await listResources({
+      app,
+      resource,
+      limit,
+      lastId: last.id,
+    });
+    return [...resources, ...newOnes];
+  }
+
+  return resources;
+}
+
+async function putUser(app, user) {
+  const body = {
+    name: user.name,
+    email: user.email,
+    welcomeMessage: user.welcomeMessage,
+    photoUrl: user.photoUrl,
+    locale: user.locale,
+    role: user.role,
+    phone: user.phone,
+    custom: user.custom,
+  };
+
+  const path = `${host}/v1/${app.id}/users/${encodeURIComponent(user.id)}`;
+  await doRequest(path, app.secretKey, "PUT", body);
+}
+
+async function conversationExists(app, conversationId) {
+  const path = `${host}/v1/${app.id}/conversations/${encodeURIComponent(conversationId)}`;
+  console.log("[TalkJS]", `Calling GET ${path}`);
+
+  const response = await fetch(path, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${app.secretKey}`,
+    },
+  });
+  await delay();
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (response.ok) {
+    return true;
+  }
+
+  const error = await response.text();
+  throw new Error(`GET ${path} failed (${response.status}): ${error}`);
+}
+
+async function putConversation(app, conversation) {
+  const participantIds = Object.keys(conversation.participants || {});
+  const body = {
+    participants: participantIds,
+    subject: conversation.subject,
+    welcomeMessages: conversation.welcomeMessages,
+    custom: conversation.custom,
+    photoUrl: conversation.photoUrl,
+  };
+
+  const path = `${host}/v1/${app.id}/conversations/${encodeURIComponent(conversation.id)}`;
+  await doRequest(path, app.secretKey, "PUT", body);
+
+  for (const [userId, participation] of Object.entries(
+    conversation.participants || {},
+  )) {
+    const participationPath =
+      `${host}/v1/${app.id}/conversations/${encodeURIComponent(conversation.id)}` +
+      `/participants/${encodeURIComponent(userId)}`;
+    await doRequest(participationPath, app.secretKey, "PUT", {
+      access: participation.access,
+      notify: participation.notify,
+    });
+  }
+}
+
+async function setParticipantReadUntil(app, conversation) {
+  for (const [userId, participation] of Object.entries(
+    conversation.participants || {},
+  )) {
+    if (participation.readUntil == null) {
+      continue;
+    }
+
+    const path =
+      `${host}/v1/${app.id}/conversations/${encodeURIComponent(conversation.id)}` +
+      `/participants/${encodeURIComponent(userId)}`;
+    await doRequest(path, app.secretKey, "PATCH", {
+      readUntil: participation.readUntil,
+    });
+  }
+}
+
+async function prepareMessageForImport(app, message) {
+  const imported = {
+    type: message.type,
+    createdAt: message.createdAt,
+  };
+
+  if (message.type === "UserMessage") {
+    imported.sender = message.senderId;
+  }
+
+  if (message.custom && Object.keys(message.custom).length > 0) {
+    imported.custom = message.custom;
+  }
+
+  let transferredAttachments = 0;
+  let failedAttachments = 0;
+
+  // Prefer structured content when present; fall back to legacy fields.
+  if (Array.isArray(message.content) && message.content.length > 0) {
+    const content = [];
+    for (const block of message.content) {
+      if (block.type === "text") {
+        content.push({ type: "text", children: block.children });
+        continue;
+      }
+
+      if (block.type === "location") {
+        content.push({
+          type: "location",
+          latitude: block.latitude,
+          longitude: block.longitude,
+        });
+        continue;
+      }
+
+      if (block.type === "file") {
+        try {
+          const fileToken = await transferFileAttachment(app, block);
+          content.push({ type: "file", fileToken });
+          transferredAttachments++;
+        } catch (err) {
+          failedAttachments++;
+          console.warn(
+            `[TalkJS] Could not transfer attachment for message ${message.id}: ${err.message}`,
+          );
+        }
+        continue;
+      }
+
+      content.push(block);
+    }
+
+    if (content.length === 0) {
+      return { message: null, transferredAttachments, failedAttachments };
+    }
+
+    imported.content = content;
+    return { message: imported, transferredAttachments, failedAttachments };
+  }
+
+  if (message.attachment) {
+    try {
+      const fileToken = await transferFileAttachment(app, message.attachment);
+      imported.content = [{ type: "file", fileToken }];
+      transferredAttachments++;
+      return { message: imported, transferredAttachments, failedAttachments };
+    } catch (err) {
+      failedAttachments++;
+      console.warn(
+        `[TalkJS] Could not transfer attachment for message ${message.id}: ${err.message}`,
+      );
+      return { message: null, transferredAttachments, failedAttachments };
+    }
+  }
+
+  if (message.text != null && message.text !== "") {
+    imported.text = message.text;
+    return { message: imported, transferredAttachments, failedAttachments };
+  }
+
+  if (message.location) {
+    imported.content = [
+      {
+        type: "location",
+        latitude: message.location[0],
+        longitude: message.location[1],
+      },
+    ];
+    return { message: imported, transferredAttachments, failedAttachments };
+  }
+
+  // Empty / unsupported message body — skip rather than fail the batch.
+  return { message: null, transferredAttachments, failedAttachments };
+}
+
+async function transferFileAttachment(app, fileBlock) {
+  if (!fileBlock?.url) {
+    throw new Error("Attachment is missing a downloadable URL");
+  }
+
+  if (uploadedFileTokens.has(fileBlock.url)) {
+    return uploadedFileTokens.get(fileBlock.url);
+  }
+
+  console.log(
+    `[TalkJS] Transferring attachment ${fileBlock.filename || fileBlock.url}`,
+  );
+
+  const downloadResponse = await fetch(fileBlock.url);
+  await delay();
+
+  if (!downloadResponse.ok) {
+    throw new Error(
+      `Failed to download attachment (${downloadResponse.status})`,
+    );
+  }
+
+  const fileBuffer = Buffer.from(await downloadResponse.arrayBuffer());
+  const filename =
+    fileBlock.filename || guessFilename(fileBlock.url, downloadResponse);
+  const contentType = downloadResponse.headers.get("content-type") || undefined;
+
+  const form = new FormData();
+  form.append("file", fileBuffer, {
+    filename,
+    contentType,
+    knownLength: fileBuffer.length,
+  });
+  form.append("filename", filename);
+
+  if (fileBlock.subtype) {
+    form.append("subtype", fileBlock.subtype);
+  }
+  if (fileBlock.width != null) {
+    form.append("width", String(fileBlock.width));
+  }
+  if (fileBlock.height != null) {
+    form.append("height", String(fileBlock.height));
+  }
+  if (fileBlock.duration != null) {
+    form.append("duration", String(fileBlock.duration));
+  }
+
+  const uploadPath = `${host}/v1/${app.id}/files`;
+  console.log("[TalkJS]", `Calling POST ${uploadPath}`);
+
+  const uploadResponse = await fetch(uploadPath, {
+    method: "POST",
+    body: form,
+    headers: {
+      Authorization: `Bearer ${app.secretKey}`,
+      ...form.getHeaders(),
+    },
+  });
+  await delay();
+
+  if (!uploadResponse.ok) {
+    const error = await uploadResponse.text();
+    throw new Error(
+      `Failed to upload attachment (${uploadResponse.status}): ${error}`,
+    );
+  }
+
+  const result = await uploadResponse.json();
+  uploadedFileTokens.set(fileBlock.url, result.fileToken);
+  return result.fileToken;
+}
+
+function guessFilename(url, response) {
+  try {
+    const pathname = new URL(url).pathname;
+    const lastSegment = pathname.split("/").filter(Boolean).pop();
+    if (lastSegment && lastSegment.includes(".")) {
+      return decodeURIComponent(lastSegment);
+    }
+  } catch {
+    // Fall through to a generic name.
+  }
+
+  const contentType = response.headers.get("content-type") || "";
+  if (contentType.startsWith("image/")) {
+    return `attachment.${contentType.split("/")[1] || "bin"}`;
+  }
+  return "attachment.bin";
+}
+
+async function importMessages(app, conversationId, messages) {
+  const path = `${host}/v1/${app.id}/import/conversations/${encodeURIComponent(conversationId)}/messages`;
+  return doRequest(path, app.secretKey, "POST", messages);
+}
+
+async function transferReactionsForBatch({
+  conversationId,
+  batch,
+  createdMessages,
+}) {
+  let transferred = 0;
+  let failed = 0;
+
+  if (
+    !Array.isArray(createdMessages) ||
+    createdMessages.length !== batch.length
+  ) {
+    console.warn(
+      `[TalkJS] Skipping reactions for conversation ${conversationId}: ` +
+        "import response did not return one new message ID per imported message.",
+    );
+    return { transferred, failed: batch.length };
+  }
+
+  for (let i = 0; i < batch.length; i++) {
+    const originMessage = batch[i].originMessage;
+    const destinationMessageId = createdMessages[i]?.id;
+    if (!destinationMessageId) {
+      failed++;
+      continue;
+    }
+
+    const result = await transferMessageReactions({
+      conversationId,
+      originMessage,
+      destinationMessageId,
+    });
+    transferred += result.transferred;
+    failed += result.failed;
+  }
+
+  return { transferred, failed };
+}
+
+async function transferMessageReactions({
+  conversationId,
+  originMessage,
+  destinationMessageId,
+}) {
+  let transferred = 0;
+  let failed = 0;
+
+  const emojis = Object.keys(originMessage.reactions || {});
+  if (emojis.length === 0) {
+    return { transferred, failed };
+  }
+
+  for (const emoji of emojis) {
+    try {
+      const reactors = await listReactionUsers(
+        originApp,
+        conversationId,
+        originMessage.id,
+        emoji,
+      );
+      for (const reactor of reactors) {
+        try {
+          await putReaction(
+            destinationApp,
+            conversationId,
+            destinationMessageId,
+            emoji,
+            reactor.userId,
+          );
+          transferred++;
+        } catch (err) {
+          failed++;
+          console.warn(
+            `[TalkJS] Could not transfer reaction ${emoji} by ${reactor.userId} ` +
+              `on message ${originMessage.id}: ${err.message}`,
+          );
+        }
+      }
+    } catch (err) {
+      failed++;
+      console.warn(
+        `[TalkJS] Could not list reactors for ${emoji} on message ${originMessage.id}: ${err.message}`,
+      );
+    }
+  }
+
+  return { transferred, failed };
+}
+
+async function listReactionUsers(app, conversationId, messageId, emoji) {
+  const path =
+    `${host}/v1/${app.id}/conversations/${encodeURIComponent(conversationId)}` +
+    `/messages/${encodeURIComponent(messageId)}` +
+    `/reactions/${encodeURIComponent(emoji)}?limit=100`;
+  const reactors = await doRequest(path, app.secretKey, "GET");
+  return Array.isArray(reactors) ? reactors : [];
+}
+
+async function putReaction(app, conversationId, messageId, emoji, userId) {
+  const path =
+    `${host}/v1/${app.id}/conversations/${encodeURIComponent(conversationId)}` +
+    `/messages/${encodeURIComponent(messageId)}` +
+    `/reactions/${encodeURIComponent(emoji)}/${encodeURIComponent(userId)}`;
+  await doRequest(path, app.secretKey, "PUT", {});
+}
+
+async function doRequest(path, secretKey, verb, body) {
+  console.log("[TalkJS]", `Calling ${verb} ${path}`);
+
+  const options = {
+    method: verb,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${secretKey}`,
+    },
+  };
+
+  if (body !== undefined) {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(path, options);
+  await delay();
+
+  if (response.ok) {
+    if (response.status === 204) {
+      return null;
+    }
+    const result = await response.json();
+    return result.data !== undefined ? result.data : result;
+  }
+
+  const error = await response.text();
+  throw new Error(`${verb} ${path} failed (${response.status}): ${error}`);
+}
+
+function delay() {
+  return new Promise((resolve) => setTimeout(resolve, REQUEST_DELAY_MS));
+}
+
+transfer().catch((err) => {
+  console.error("\nTransfer failed:", err.message);
+  process.exit(1);
+});

--- a/rest-api/transfer-data/transferData.js
+++ b/rest-api/transfer-data/transferData.js
@@ -312,83 +312,46 @@ async function prepareMessageForImport(app, message) {
 
   let transferredAttachments = 0;
   let failedAttachments = 0;
+  const content = [];
 
-  // Prefer structured content when present; fall back to legacy fields.
-  if (Array.isArray(message.content) && message.content.length > 0) {
-    const content = [];
-    for (const block of message.content) {
-      if (block.type === "text") {
-        content.push({ type: "text", children: block.children });
-        continue;
-      }
-
-      if (block.type === "location") {
-        content.push({
-          type: "location",
-          latitude: block.latitude,
-          longitude: block.longitude,
-        });
-        continue;
-      }
-
-      if (block.type === "file") {
-        try {
-          const fileToken = await transferFileAttachment(app, block);
-          content.push({ type: "file", fileToken });
-          transferredAttachments++;
-        } catch (err) {
-          failedAttachments++;
-          console.warn(
-            `[TalkJS] Could not transfer attachment for message ${message.id}: ${err.message}`,
-          );
-        }
-        continue;
-      }
-
-      content.push(block);
+  for (const block of message.content) {
+    if (block.type === "text") {
+      content.push({ type: "text", children: block.children });
+      continue;
     }
 
-    if (content.length === 0) {
-      return { message: null, transferredAttachments, failedAttachments };
-    }
-
-    imported.content = content;
-    return { message: imported, transferredAttachments, failedAttachments };
-  }
-
-  if (message.attachment) {
-    try {
-      const fileToken = await transferFileAttachment(app, message.attachment);
-      imported.content = [{ type: "file", fileToken }];
-      transferredAttachments++;
-      return { message: imported, transferredAttachments, failedAttachments };
-    } catch (err) {
-      failedAttachments++;
-      console.warn(
-        `[TalkJS] Could not transfer attachment for message ${message.id}: ${err.message}`,
-      );
-      return { message: null, transferredAttachments, failedAttachments };
-    }
-  }
-
-  if (message.text != null && message.text !== "") {
-    imported.text = message.text;
-    return { message: imported, transferredAttachments, failedAttachments };
-  }
-
-  if (message.location) {
-    imported.content = [
-      {
+    if (block.type === "location") {
+      content.push({
         type: "location",
-        latitude: message.location[0],
-        longitude: message.location[1],
-      },
-    ];
-    return { message: imported, transferredAttachments, failedAttachments };
+        latitude: block.latitude,
+        longitude: block.longitude,
+      });
+      continue;
+    }
+
+    if (block.type === "file") {
+      try {
+        const fileToken = await transferFileAttachment(app, block);
+        content.push({ type: "file", fileToken });
+        transferredAttachments++;
+      } catch (err) {
+        failedAttachments++;
+        console.warn(
+          `[TalkJS] Could not transfer attachment for message ${message.id}: ${err.message}`,
+        );
+      }
+      continue;
+    }
+
+    content.push(block);
   }
 
-  // Empty / unsupported message body — skip rather than fail the batch.
-  return { message: null, transferredAttachments, failedAttachments };
+  if (content.length === 0) {
+    return { message: null, transferredAttachments, failedAttachments };
+  }
+
+  imported.content = content;
+  return { message: imported, transferredAttachments, failedAttachments };
 }
 
 async function transferFileAttachment(app, fileBlock) {


### PR DESCRIPTION
On a regular basis, we have customers asking us to transfer data from their test environment to the live one. We usually advise them to use the REST API for this. While we already have a sample on how to export your data, i thought it'd be a good idea to also give them a simple ready-to-use script for doign the transfer.
